### PR TITLE
Release `v1.0.0` Citation File Updates

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -46,10 +46,10 @@
   ],
   "title": "Image Embedding Explorer",
 
-  "version": "0.1.0",
+  "version": "1.0.0",
   
   "license": {"id": "MIT"},
-  "publication_date": "2026-03-02",
+  "publication_date": "2026-03-03",
   
   "grants": [
     {"id": "021nxhr62::2118240"}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -40,7 +40,7 @@ identifiers:
     value: "https://github.com/Imageomics/emb-explorer/releases/tag/v1.0.0"
   - description: "The GitHub URL of the commit tagged with v1.0.0."
     type: url
-    value: "https://github.com/Imageomics/emb-explorer/tree" # update on release
+    value: "https://github.com/Imageomics/emb-explorer/tree/<commit-hash>" # update on release
 keywords:
   - imageomics
   - embeddings

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -40,7 +40,7 @@ identifiers:
     value: "https://github.com/Imageomics/emb-explorer/releases/tag/v1.0.0"
   - description: "The GitHub URL of the commit tagged with v1.0.0."
     type: url
-    value: "https://github.com/Imageomics/emb-explorer/commit/b1c3c695e524ec07ef5e77ee4ca85ab13b772667"
+    value: "https://github.com/Imageomics/emb-explorer/tree" # update on release
 keywords:
   - imageomics
   - embeddings

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,14 +33,14 @@ authors:
     orcid: "https://orcid.org/0000-0002-4138-603X"
     affiliation: The Ohio State University
 cff-version: 1.2.0
-date-released: "2026-03-02"
+date-released: "2026-03-03"
 identifiers:
-  - description: "The GitHub release URL of tag v0.1.0." 
+  - description: "The GitHub release URL of tag v1.0.0." 
     type: url
-    value: "https://github.com/Imageomics/emb-explorer/releases/tag/v0.1.0"
-  - description: "The GitHub URL of the commit tagged with v0.1.0."
+    value: "https://github.com/Imageomics/emb-explorer/releases/tag/v1.0.0"
+  - description: "The GitHub URL of the commit tagged with v1.0.0."
     type: url
-    value: "https://github.com/Imageomics/emb-explorer/tree/c51be4ef536f5f87fc4f49619ff764c10e103416"
+    value: "https://github.com/Imageomics/emb-explorer/commit/b1c3c695e524ec07ef5e77ee4ca85ab13b772667"
 keywords:
   - imageomics
   - embeddings
@@ -51,6 +51,6 @@ license: MIT
 message: "If you find this software helpful in your research, please cite both the software."
 repository-code: "https://github.com/Imageomics/emb-explorer"
 title: "Image Embedding Explorer"
-version: 0.1.0
+version: 1.0.0
 doi: 10.5281/zenodo.18841337
 type: software

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "emb-explorer"
-version = "0.1.0"
+version = "1.0.0"
 description = "Image clustering tool using embeddings with Streamlit interface"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
This pull request updates the project metadata and documentation to reflect the new `v1.0.0` release. The changes ensure consistency across files regarding the version number, release date, and associated URLs.

Release and metadata updates:

* Bumped the project version from `0.1.0` to `1.0.0` in `.zenodo.json`, `CITATION.cff`, and `pyproject.toml` to mark the new release. [[1]](diffhunk://#diff-69450eccf330a9c709df151fad75b5a9c02976ac29bd5d251bb16eb367997892L49-R52) [[2]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295L54-R54) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7)
* Updated the release date from `2026-03-02` to `2026-03-03` in `.zenodo.json` and `CITATION.cff`. [[1]](diffhunk://#diff-69450eccf330a9c709df151fad75b5a9c02976ac29bd5d251bb16eb367997892L49-R52) [[2]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295L36-R43)
* Changed GitHub release and commit URLs in `CITATION.cff` to point to the new `v1.0.0` tag and commit.