### PR TITLE
Update commit URL for v1.0.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -40,7 +40,7 @@ identifiers:
     value: "https://github.com/Imageomics/emb-explorer/releases/tag/v1.0.0"
   - description: "The GitHub URL of the commit tagged with v1.0.0."
     type: url
-    value: "https://github.com/Imageomics/emb-explorer/tree/<commit-hash>" # update on release
+    value: "https://github.com/Imageomics/emb-explorer/tree/4e4ef6dc6e6d3a179206f024ff4f2a93a61669c2" 
 keywords:
   - imageomics
   - embeddings


### PR DESCRIPTION
Updated the commit URL to the specific commit hash for v1.0.0.