### PR TITLE
Cap Python at <3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ Visual exploration and clustering tool for image embeddings. Users can either br
 
 ## Installation
 
+Requires Python 3.10–3.13. We recommend using [uv](https://github.com/astral-sh/uv) for package management.
+
 ```bash
 git clone https://github.com/Imageomics/emb-explorer.git
 cd emb-explorer
 
-# Using uv (recommended)
-uv venv && source .venv/bin/activate
+# Create venv with Python 3.12 (3.14+ not yet supported by GPU dependencies)
+uv venv --python 3.12 && source .venv/bin/activate
 uv pip install -e .
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Multimedia :: Graphics",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 dependencies = [
     # Core UI and web framework
     "streamlit>=1.50.0",


### PR DESCRIPTION
`cuml-cu12` and `numba` do not yet ship wheels for Python 3.14. Cap requires-python to <3.14 so users get a clear error upfront, in the README install section pinned the bash command to `--python 3.12`

Add link to uv Github repo for installation instruction

Closes #18