### PR TITLE
Add clustering evaluation with color toggle, ARI/NMI, and cluster analysis

### DIFF
--- a/apps/precalculated/app.py
+++ b/apps/precalculated/app.py
@@ -12,7 +12,7 @@ from apps.precalculated.components.sidebar import (
     render_dynamic_filters,
     render_clustering_section,
 )
-from apps.precalculated.components.data_preview import render_data_preview
+from apps.precalculated.components.data_preview import render_data_preview, render_cluster_analysis
 from shared.components.visualization import render_scatter_plot
 from shared.components.summary import render_clustering_summary
 
@@ -69,8 +69,9 @@ def app():
     with col_preview:
         render_data_preview()
 
-    # Bottom: Clustering summary
+    # Bottom: Cluster analysis (evaluation mode) + taxonomy summary
     st.markdown("---")
+    render_cluster_analysis()
     render_clustering_summary(show_taxonomy=True)
 
 

--- a/apps/precalculated/components/__init__.py
+++ b/apps/precalculated/components/__init__.py
@@ -5,7 +5,7 @@ from apps.precalculated.components.sidebar import (
     render_dynamic_filters,
     render_clustering_section,
 )
-from apps.precalculated.components.data_preview import render_data_preview
+from apps.precalculated.components.data_preview import render_data_preview, render_cluster_analysis
 from apps.precalculated.components.visualization import render_scatter_plot
 
 __all__ = [
@@ -13,5 +13,6 @@ __all__ = [
     "render_dynamic_filters",
     "render_clustering_section",
     "render_data_preview",
+    "render_cluster_analysis",
     "render_scatter_plot",
 ]

--- a/apps/precalculated/components/data_preview.py
+++ b/apps/precalculated/components/data_preview.py
@@ -5,6 +5,7 @@ Dynamically displays all available metadata fields.
 
 import streamlit as st
 import pandas as pd
+import numpy as np
 import requests
 import time
 from typing import Optional
@@ -80,10 +81,32 @@ def get_image_from_url(url: str) -> Optional[Image.Image]:
 
 
 def render_data_preview():
-    """Render the data preview panel with dynamic field display."""
+    """Render the data preview panel (record details on point click)."""
+    _render_record_details()
+
+
+def render_cluster_analysis():
+    """Render cluster analysis section (call from full-width bottom area)."""
     df_plot = st.session_state.get("data", None)
     labels = st.session_state.get("labels", None)
-    selected_idx = st.session_state.get("selected_image_idx", None)  # Default to None, not 0
+
+    taxonomic_info = st.session_state.get("taxonomic_clustering", {})
+    evaluation_column = taxonomic_info.get("evaluation_column")
+
+    if (
+        evaluation_column
+        and df_plot is not None
+        and evaluation_column in df_plot.columns
+        and labels is not None
+    ):
+        _render_cluster_analysis(df_plot, labels, evaluation_column)
+
+
+def _render_record_details():
+    """Render the record details panel (existing functionality)."""
+    df_plot = st.session_state.get("data", None)
+    labels = st.session_state.get("labels", None)
+    selected_idx = st.session_state.get("selected_image_idx", None)
     filtered_df = st.session_state.get("filtered_df_for_clustering", None)
 
     # Validate that selection matches current data version
@@ -115,7 +138,7 @@ def render_data_preview():
         # Find the full record
         record = filtered_df[filtered_df['uuid'] == selected_uuid].iloc[0]
 
-        st.markdown("### 📋 Record Details")
+        st.markdown("### Record Details")
 
         # Try to display image if identifier/url column exists (cached to prevent re-fetch)
         image_cols = ['identifier', 'image_url', 'url', 'img_url', 'image']
@@ -154,7 +177,7 @@ def render_data_preview():
         # Display remaining metadata as table
         if metadata_rows:
             st.markdown("---")
-            st.markdown("**📊 Metadata**")
+            st.markdown("**Metadata**")
             metadata_df = pd.DataFrame(metadata_rows)
             st.dataframe(
                 metadata_df,
@@ -169,14 +192,14 @@ def render_data_preview():
     else:
         # Show appropriate message based on state
         if df_plot is not None and labels is not None:
-            st.info("📋 Click a point in the scatter plot to view its details.")
+            st.info("Click a point in the scatter plot to view its details.")
         else:
-            st.info("📋 Run clustering first, then click a point to view details.")
+            st.info("Run clustering first, then click a point to view details.")
 
         # Show dataset summary
         filtered_df = st.session_state.get("filtered_df", None)
         if filtered_df is not None and len(filtered_df) > 0:
-            st.markdown("### 📈 Dataset Summary")
+            st.markdown("### Dataset Summary")
             st.markdown(f"**Records:** {len(filtered_df):,}")
 
             # Show column stats
@@ -185,4 +208,75 @@ def render_data_preview():
                 with st.expander("Column overview"):
                     for col, info in list(column_info.items())[:10]:
                         unique = len(info['unique_values']) if info['unique_values'] else "many"
-                        st.caption(f"• **{col}** ({info['type']}): {unique} unique")
+                        st.caption(f"**{col}** ({info['type']}): {unique} unique")
+
+
+def _compute_entropy(counts):
+    """Shannon entropy in bits."""
+    total = sum(counts)
+    if total == 0:
+        return 0.0
+    probs = [c / total for c in counts if c > 0]
+    return -sum(p * np.log2(p) for p in probs)
+
+
+def _build_cluster_tree(df_plot, evaluation_column):
+    """Build a tree-style string summarizing cluster composition against ground truth."""
+    unique_clusters = sorted(df_plot['cluster'].unique(), key=lambda x: int(x))
+    n_total = len(df_plot)
+    n_clusters = len(unique_clusters)
+
+    lines = []
+    lines.append(f'KMeans Clustering Summary ({n_total} points, {n_clusters} clusters)')
+    lines.append(f'Evaluation column: {evaluation_column}')
+    lines.append('')
+
+    for ci, cluster_id in enumerate(unique_clusters):
+        is_last_cluster = (ci == n_clusters - 1)
+        mask = df_plot['cluster'] == cluster_id
+        cluster_df = df_plot[mask]
+        n = len(cluster_df)
+
+        gt_counts = cluster_df[evaluation_column].value_counts()
+        purity = gt_counts.iloc[0] / n if n > 0 else 0
+        dominant = gt_counts.index[0]
+        entropy = _compute_entropy(gt_counts.values)
+
+        prefix = '\u2514\u2500\u2500 ' if is_last_cluster else '\u251c\u2500\u2500 '
+        lines.append(f'{prefix}Cluster {cluster_id}  [{n} pts]  purity: {purity:.0%}  entropy: {entropy:.2f}')
+
+        child_prefix = '    ' if is_last_cluster else '\u2502   '
+        for ji, (cat, count) in enumerate(gt_counts.items()):
+            is_last_cat = (ji == len(gt_counts) - 1)
+            pct = count / n * 100
+            cat_connector = '\u2514\u2500 ' if is_last_cat else '\u251c\u2500 '
+            lines.append(f'{child_prefix}{cat_connector}{cat:<20s} {count:>4d}  {pct:>5.1f}%')
+
+    return '\n'.join(lines)
+
+
+def _render_cluster_analysis(df_plot, labels, evaluation_column):
+    """Render cluster analysis with per-cluster breakdown against ground truth."""
+    eval_metrics = st.session_state.get('evaluation_metrics')
+
+    # Overall metrics
+    if eval_metrics:
+        st.markdown(f"### Evaluation vs `{evaluation_column}`")
+        col1, col2, col3 = st.columns(3)
+        with col1:
+            st.metric("ARI", f"{eval_metrics['ari']:.3f}",
+                      help="Adjusted Rand Index: 1 = perfect, 0 = random, <0 = worse than random")
+        with col2:
+            st.metric("NMI", f"{eval_metrics['nmi']:.3f}",
+                      help="Normalized Mutual Information: 1 = perfect, 0 = no correlation")
+        with col3:
+            st.metric("Evaluated", f"{eval_metrics['n_evaluated']:,}",
+                      help="Rows with non-null ground truth")
+        if eval_metrics.get('n_null_excluded', 0) > 0:
+            st.caption(f"{eval_metrics['n_null_excluded']:,} null rows excluded")
+
+    st.markdown("---")
+
+    # Tree-style cluster summary
+    tree_output = _build_cluster_tree(df_plot, evaluation_column)
+    st.code(tree_output, language="text")

--- a/apps/precalculated/components/sidebar.py
+++ b/apps/precalculated/components/sidebar.py
@@ -18,6 +18,7 @@ from shared.services.clustering_service import ClusteringService
 from shared.components.clustering_controls import render_clustering_backend_controls
 from shared.utils.backend import check_cuda_available, resolve_backend, is_oom_error
 from shared.utils.logging_config import get_logger
+from sklearn.metrics import adjusted_rand_score, normalized_mutual_info_score
 
 logger = get_logger(__name__)
 
@@ -556,14 +557,14 @@ def render_clustering_section() -> Tuple[bool, int, str, str, str, int, Optional
         cluster_method = st.radio(
             "Cluster count method:",
             ["Specify number", "Use column values"],
-            horizontal=True
+            horizontal=True,
+            help="Specify number: manual KMeans | Use column values: KMeans with cluster count from column (for evaluation)"
         )
 
         if cluster_method == "Specify number":
             n_clusters = st.slider("Number of clusters", 2, min(100, len(filtered_df)//2), 5)
             cluster_column = None
         else:
-            # Get categorical columns for clustering
             column_info = st.session_state.get("column_info", {})
             categorical_cols = [k for k, v in column_info.items() if v['type'] == 'categorical']
 
@@ -574,8 +575,23 @@ def render_clustering_section() -> Tuple[bool, int, str, str, str, int, Optional
                     help="Number of clusters = unique values in selected column"
                 )
                 if cluster_column in filtered_df.columns:
-                    n_clusters = filtered_df[cluster_column].nunique()
-                    st.info(f"Using **{n_clusters}** clusters from {cluster_column}")
+                    n_unique = filtered_df[cluster_column].nunique()
+                    null_count = filtered_df[cluster_column].isna().sum()
+
+                    if n_unique > 16:
+                        st.error(
+                            f"**{cluster_column}** has {n_unique} unique values — "
+                            f"exceeds the 16-color limit. Colors will repeat and "
+                            f"make the plot misleading. Filter the data to reduce "
+                            f"cardinality first."
+                        )
+                        n_clusters = n_unique
+                    else:
+                        n_clusters = n_unique
+                        msg = f"KMeans with **{n_clusters}** clusters (from {cluster_column} unique values)"
+                        if null_count > 0:
+                            msg += f" | {null_count} rows with null values"
+                        st.info(msg)
                 else:
                     n_clusters = 5
             else:
@@ -592,13 +608,17 @@ def render_clustering_section() -> Tuple[bool, int, str, str, str, int, Optional
         # Backend controls
         dim_reduction_backend, clustering_backend, n_workers, seed = render_clustering_backend_controls()
 
-        cluster_button = st.button("Run Clustering", type="primary")
+        # Block clustering when cardinality exceeds color limit
+        cardinality_ok = not (cluster_column and cluster_column in filtered_df.columns
+                              and filtered_df[cluster_column].nunique() > 16)
 
-        if cluster_button:
+        cluster_button = st.button("Run Clustering", type="primary", disabled=not cardinality_ok)
+
+        if cluster_button and cardinality_ok:
             run_clustering_with_error_handling(
                 filtered_df, n_clusters, reduction_method,
                 dim_reduction_backend, clustering_backend, n_workers, seed,
-                cluster_column if cluster_method == "Use column values" else None
+                cluster_column=cluster_column if cluster_method == "Use column values" else None
             )
 
         return cluster_button, n_clusters, reduction_method, dim_reduction_backend, clustering_backend, n_workers, seed
@@ -616,6 +636,11 @@ def run_clustering_with_error_handling(
 ):
     """
     Run clustering with comprehensive error handling for VRAM and CUDA issues.
+
+    Supports two modes:
+    - Specify number: KMeans with user-specified n_clusters (cluster_column=None)
+    - Use column values: KMeans with n_clusters from column, preserving KMeans labels
+      for evaluation against the column's ground truth (cluster_column set)
     """
     try:
         # Check CUDA availability
@@ -647,7 +672,7 @@ def run_clustering_with_error_handling(
         logger.info(f"Memory: ~{mem_mb:.1f} MB | Clusters: {n_clusters}")
         logger.info(f"Embeddings extracted ({t_extract:.2f}s)")
 
-        # Run clustering with automatic GPU fallback
+        # Run KMeans + dim reduction
         t_cluster_start = time.time()
         with st.spinner(f"Running {reduction_method} + KMeans..."):
             df_plot, labels = ClusteringService.run_clustering_safe(
@@ -664,37 +689,46 @@ def run_clustering_with_error_handling(
         t_cluster = time.time() - t_cluster_start
         t_total = time.time() - t_start
 
-        # Log clustering completion to console
+        # Log completion
         logger.info(f"{reduction_method} + KMeans completed ({t_cluster:.2f}s)")
         logger.info(f"Total time: {t_total:.2f}s")
 
-        # Create enhanced plot dataframe
+        # Create enhanced plot dataframe (preserves KMeans labels)
         df_plot = create_cluster_dataframe(filtered_df.reset_index(drop=True), df_plot[['x', 'y']].values, labels)
+        df_plot['cluster_name'] = df_plot['cluster'].copy()
 
-        # Handle column-based cluster names
         if cluster_column and cluster_column in filtered_df.columns:
-            filtered_reset = filtered_df.reset_index(drop=True)
-            unique_taxa = sorted(filtered_df[cluster_column].dropna().unique())
-            taxon_to_id = {taxon: str(i) for i, taxon in enumerate(unique_taxa)}
+            # "Use column values" mode: KMeans labels preserved for evaluation
+            st.session_state.taxonomic_clustering = {
+                'is_taxonomic': False,
+                'evaluation_column': cluster_column
+            }
 
-            taxonomic_names = []
-            numeric_clusters = []
-
-            for idx in range(len(df_plot)):
-                taxon_value = filtered_reset.iloc[idx][cluster_column]
-                if pd.notna(taxon_value) and taxon_value in taxon_to_id:
-                    taxonomic_names.append(str(taxon_value))
-                    numeric_clusters.append(taxon_to_id[taxon_value])
-                else:
-                    taxonomic_names.append("Unknown")
-                    numeric_clusters.append(str(len(unique_taxa)))
-
-            df_plot['cluster'] = numeric_clusters
-            df_plot['cluster_name'] = taxonomic_names
-            st.session_state.taxonomic_clustering = {'is_taxonomic': True, 'column': cluster_column}
+            # Compute ARI/NMI: compare KMeans labels vs ground truth column
+            ground_truth = filtered_df.reset_index(drop=True)[cluster_column]
+            non_null_mask = ground_truth.notna()
+            if non_null_mask.sum() > 0:
+                gt_values = ground_truth[non_null_mask].values
+                kmeans_labels_for_eval = labels[non_null_mask.values]
+                ari = adjusted_rand_score(gt_values, kmeans_labels_for_eval)
+                nmi = normalized_mutual_info_score(
+                    gt_values, kmeans_labels_for_eval, average_method='arithmetic'
+                )
+                st.session_state.evaluation_metrics = {
+                    'ari': ari,
+                    'nmi': nmi,
+                    'evaluation_column': cluster_column,
+                    'n_evaluated': int(non_null_mask.sum()),
+                    'n_null_excluded': int((~non_null_mask).sum()),
+                }
+                logger.info(f"Evaluation metrics: ARI={ari:.4f}, NMI={nmi:.4f} "
+                            f"({non_null_mask.sum()} rows evaluated, "
+                            f"{(~non_null_mask).sum()} null rows excluded)")
+            else:
+                st.session_state.evaluation_metrics = None
         else:
-            df_plot['cluster_name'] = df_plot['cluster'].copy()
             st.session_state.taxonomic_clustering = {'is_taxonomic': False}
+            st.session_state.evaluation_metrics = None
 
         # Store results with data version tracking
         data_hash = hashlib.md5(f"{len(df_plot)}_{n_clusters}_{reduction_method}".encode()).hexdigest()[:8]

--- a/shared/components/visualization.py
+++ b/shared/components/visualization.py
@@ -33,8 +33,16 @@ def _render_chart_fragment(df_plot):
     # Track previous density mode to detect changes
     prev_density_mode = st.session_state.get("_prev_density_mode", None)
 
+    # Check if color toggle is available (evaluation mode: "Use column values")
+    taxonomic_info = st.session_state.get("taxonomic_clustering", {})
+    evaluation_column = taxonomic_info.get("evaluation_column")
+    show_color_toggle = bool(evaluation_column and evaluation_column in df_plot.columns)
+
     # Plot options in columns for compact layout
-    opt_col1, opt_col2 = st.columns([2, 1])
+    if show_color_toggle:
+        opt_col1, opt_col_color, opt_col2 = st.columns([2, 2, 1])
+    else:
+        opt_col1, opt_col2 = st.columns([2, 1])
 
     with opt_col1:
         density_mode = st.radio(
@@ -45,6 +53,19 @@ def _render_chart_fragment(df_plot):
             key="density_mode",
             help="Off: normal view | Opacity: lower opacity to show overlap | Heatmap: 2D binned density (disables selection)"
         )
+
+    # Color toggle for evaluation mode
+    if show_color_toggle:
+        with opt_col_color:
+            color_by = st.radio(
+                "Color by",
+                options=["KMeans Cluster", evaluation_column],
+                horizontal=True,
+                key="color_by_toggle",
+                help=f"Switch between KMeans cluster assignments and ground truth '{evaluation_column}' values"
+            )
+    else:
+        color_by = None
 
     # Log density mode change
     if prev_density_mode != density_mode:
@@ -104,8 +125,16 @@ def _render_chart_fragment(df_plot):
     else:
         point_opacity = 0.7  # Normal opacity
 
+    # Determine color encoding based on toggle
+    if color_by and color_by != "KMeans Cluster":
+        color_col = color_by
+        color_title = color_by
+    else:
+        color_col = 'cluster'
+        color_title = cluster_legend_title
+
     # Sort legend labels: numeric sort for cluster IDs, alphabetical for strings
-    unique_vals = df_plot['cluster'].unique()
+    unique_vals = df_plot[color_col].unique()
     try:
         sorted_vals = sorted(unique_vals, key=int)
     except (ValueError, TypeError):
@@ -119,8 +148,8 @@ def _render_chart_fragment(df_plot):
             x=alt.X('x:Q', scale=alt.Scale(zero=False)),
             y=alt.Y('y:Q', scale=alt.Scale(zero=False)),
             color=alt.Color(
-                'cluster:N',
-                legend=alt.Legend(title=cluster_legend_title),
+                f'{color_col}:N',
+                legend=alt.Legend(title=color_title),
                 sort=sorted_vals
             ),
             tooltip=tooltip_fields,


### PR DESCRIPTION
## Summary

Adds evaluation capabilities to the "Use column values" clustering mode, allowing users to assess how well KMeans clusters align with known categorical labels.

- **Color toggle**: radio in plot options to switch between KMeans cluster coloring and ground truth column coloring -- same points, same positions, instant comparison
- **ARI/NMI metrics**: Adjusted Rand Index and Normalized Mutual Information computed automatically after KMeans, displayed in the Cluster Analysis section
- **Cluster analysis tree**: full-width console output showing per-cluster composition with purity, entropy, and ranked breakdown by ground truth category
- **Cardinality cap at 16**: blocks clustering when column has >16 unique values to prevent misleading duplicate colors -- suggests filtering first
- **Removed "Label by column" mode**: redundant with the color toggle in "Use column values"
- **Cleaned up** unused `run_dim_reduction`/`run_dim_reduction_safe` from ClusteringService

Depends on #22

Generated with [Claude Code](https://claude.com/claude-code)