### PR TITLE
Separate dim reduction and KMeans into independent operations

### DIFF
--- a/apps/precalculated/app.py
+++ b/apps/precalculated/app.py
@@ -10,7 +10,8 @@ import streamlit as st
 from apps.precalculated.components.sidebar import (
     render_file_section,
     render_dynamic_filters,
-    render_clustering_section,
+    render_projection_section,
+    render_kmeans_section,
 )
 from apps.precalculated.components.data_preview import render_data_preview
 from shared.components.visualization import render_scatter_plot
@@ -38,7 +39,7 @@ def app():
     # Initialize session state
     if "page_type" not in st.session_state or st.session_state.page_type != "precalculated_app":
         # Clear any stale state from other apps
-        keys_to_clear = ["embeddings", "valid_paths", "last_image_dir", "embedding_complete"]
+        keys_to_clear = ["embeddings", "valid_paths", "last_image_dir", "embedding_complete", "kmeans_column"]
         for key in keys_to_clear:
             if key in st.session_state:
                 del st.session_state[key]
@@ -61,7 +62,8 @@ def app():
     col_settings, col_plot, col_preview = st.columns([2, 7, 3])
 
     with col_settings:
-        render_clustering_section()
+        render_projection_section()
+        render_kmeans_section()
 
     with col_plot:
         render_scatter_plot()
@@ -69,7 +71,7 @@ def app():
     with col_preview:
         render_data_preview()
 
-    # Bottom: Clustering summary
+    # Bottom: Taxonomy summary
     st.markdown("---")
     render_clustering_summary(show_taxonomy=True)
 

--- a/apps/precalculated/components/__init__.py
+++ b/apps/precalculated/components/__init__.py
@@ -3,7 +3,8 @@
 from apps.precalculated.components.sidebar import (
     render_file_section,
     render_dynamic_filters,
-    render_clustering_section,
+    render_projection_section,
+    render_kmeans_section,
 )
 from apps.precalculated.components.data_preview import render_data_preview
 from apps.precalculated.components.visualization import render_scatter_plot
@@ -11,7 +12,8 @@ from apps.precalculated.components.visualization import render_scatter_plot
 __all__ = [
     "render_file_section",
     "render_dynamic_filters",
-    "render_clustering_section",
+    "render_projection_section",
+    "render_kmeans_section",
     "render_data_preview",
     "render_scatter_plot",
 ]

--- a/apps/precalculated/components/data_preview.py
+++ b/apps/precalculated/components/data_preview.py
@@ -110,7 +110,7 @@ def render_data_preview():
 
         st.markdown("### Record Details")
 
-        # Try to display image
+        # Try to display image if identifier/url column exists (cached to prevent re-fetch)
         image_cols = ['identifier', 'image_url', 'url', 'img_url', 'image']
         for img_col in image_cols:
             if img_col in record.index and pd.notna(record[img_col]):
@@ -122,7 +122,7 @@ def render_data_preview():
 
         st.markdown(f"**UUID:** `{selected_uuid}`")
 
-        # Build metadata table
+        # Build metadata table for remaining fields
         skip_fields = {'emb', 'embedding', 'embeddings', 'vector', 'idx', 'uuid'}
 
         metadata_rows = []
@@ -156,6 +156,7 @@ def render_data_preview():
             )
 
     else:
+        # Show appropriate message based on state
         if df_plot is not None:
             st.info("Click a point in the scatter plot to view its details.")
         else:

--- a/apps/precalculated/components/data_preview.py
+++ b/apps/precalculated/components/data_preview.py
@@ -5,6 +5,7 @@ Dynamically displays all available metadata fields.
 
 import streamlit as st
 import pandas as pd
+import numpy as np
 import requests
 import time
 from typing import Optional
@@ -80,10 +81,10 @@ def get_image_from_url(url: str) -> Optional[Image.Image]:
 
 
 def render_data_preview():
-    """Render the data preview panel with dynamic field display."""
+    """Render the data preview panel (record details on point click)."""
     df_plot = st.session_state.get("data", None)
     labels = st.session_state.get("labels", None)
-    selected_idx = st.session_state.get("selected_image_idx", None)  # Default to None, not 0
+    selected_idx = st.session_state.get("selected_image_idx", None)
     filtered_df = st.session_state.get("filtered_df_for_clustering", None)
 
     # Validate that selection matches current data version
@@ -97,27 +98,19 @@ def render_data_preview():
 
     if (
         df_plot is not None and
-        labels is not None and
         selection_valid and
         0 <= selected_idx < len(df_plot) and
         filtered_df is not None
     ):
         # Get the selected record
         selected_uuid = df_plot.iloc[selected_idx]['uuid']
-        cluster = labels[selected_idx] if labels is not None else "?"
-
-        # Use cluster_name if available
-        if 'cluster_name' in df_plot.columns:
-            cluster_display = df_plot.iloc[selected_idx]['cluster_name']
-        else:
-            cluster_display = cluster
 
         # Find the full record
         record = filtered_df[filtered_df['uuid'] == selected_uuid].iloc[0]
 
-        st.markdown("### 📋 Record Details")
+        st.markdown("### Record Details")
 
-        # Try to display image if identifier/url column exists (cached to prevent re-fetch)
+        # Try to display image
         image_cols = ['identifier', 'image_url', 'url', 'img_url', 'image']
         for img_col in image_cols:
             if img_col in record.index and pd.notna(record[img_col]):
@@ -127,12 +120,10 @@ def render_data_preview():
                     st.image(image, width=280)
                     break
 
-        # Display Cluster and UUID prominently (not in table)
-        st.markdown(f"**Cluster:** `{cluster_display}`")
         st.markdown(f"**UUID:** `{selected_uuid}`")
 
-        # Build metadata table for remaining fields
-        skip_fields = {'emb', 'embedding', 'embeddings', 'vector', 'idx', 'uuid', 'cluster', 'cluster_name'}
+        # Build metadata table
+        skip_fields = {'emb', 'embedding', 'embeddings', 'vector', 'idx', 'uuid'}
 
         metadata_rows = []
         for field, value in record.items():
@@ -141,7 +132,6 @@ def render_data_preview():
             if pd.isna(value):
                 continue
 
-            # Format value
             if isinstance(value, float):
                 display_val = f"{value:.4f}"
             elif isinstance(value, (list, tuple)):
@@ -151,10 +141,9 @@ def render_data_preview():
 
             metadata_rows.append({"Field": field, "Value": display_val})
 
-        # Display remaining metadata as table
         if metadata_rows:
             st.markdown("---")
-            st.markdown("**📊 Metadata**")
+            st.markdown("**Metadata**")
             metadata_df = pd.DataFrame(metadata_rows)
             st.dataframe(
                 metadata_df,
@@ -167,22 +156,122 @@ def render_data_preview():
             )
 
     else:
-        # Show appropriate message based on state
-        if df_plot is not None and labels is not None:
-            st.info("📋 Click a point in the scatter plot to view its details.")
+        if df_plot is not None:
+            st.info("Click a point in the scatter plot to view its details.")
         else:
-            st.info("📋 Run clustering first, then click a point to view details.")
+            st.info("Run projection first, then click a point to view details.")
 
         # Show dataset summary
-        filtered_df = st.session_state.get("filtered_df", None)
-        if filtered_df is not None and len(filtered_df) > 0:
-            st.markdown("### 📈 Dataset Summary")
-            st.markdown(f"**Records:** {len(filtered_df):,}")
+        filtered_df_summary = st.session_state.get("filtered_df", None)
+        if filtered_df_summary is not None and len(filtered_df_summary) > 0:
+            st.markdown("### Dataset Summary")
+            st.markdown(f"**Records:** {len(filtered_df_summary):,}")
 
-            # Show column stats
             column_info = st.session_state.get("column_info", {})
             if column_info:
                 with st.expander("Column overview"):
                     for col, info in list(column_info.items())[:10]:
                         unique = len(info['unique_values']) if info['unique_values'] else "many"
-                        st.caption(f"• **{col}** ({info['type']}): {unique} unique")
+                        st.caption(f"**{col}** ({info['type']}): {unique} unique")
+
+
+def _compute_entropy(counts):
+    """Shannon entropy in bits."""
+    total = sum(counts)
+    if total == 0:
+        return 0.0
+    probs = [c / total for c in counts if c > 0]
+    return -sum(p * np.log2(p) for p in probs)
+
+
+def _build_cluster_tree(df_plot, kmeans_col, compare_col):
+    """Build a tree-style string summarizing cluster composition against a comparison column."""
+    unique_clusters = sorted(df_plot[kmeans_col].unique(), key=lambda x: int(x))
+    n_total = len(df_plot)
+    n_clusters = len(unique_clusters)
+
+    lines = []
+    lines.append(f'KMeans Clustering Summary ({n_total} points, {n_clusters} clusters)')
+    lines.append(f'Compared against: {compare_col}')
+    lines.append('')
+
+    for ci, cluster_id in enumerate(unique_clusters):
+        is_last_cluster = (ci == n_clusters - 1)
+        mask = df_plot[kmeans_col] == cluster_id
+        cluster_df = df_plot[mask]
+        n = len(cluster_df)
+
+        gt_counts = cluster_df[compare_col].value_counts()
+        purity = gt_counts.iloc[0] / n if n > 0 else 0
+        entropy = _compute_entropy(gt_counts.values)
+
+        prefix = '\u2514\u2500\u2500 ' if is_last_cluster else '\u251c\u2500\u2500 '
+        lines.append(f'{prefix}Cluster {cluster_id}  [{n} pts]  purity: {purity:.0%}  entropy: {entropy:.2f}')
+
+        child_prefix = '    ' if is_last_cluster else '\u2502   '
+        for ji, (cat, count) in enumerate(gt_counts.items()):
+            is_last_cat = (ji == len(gt_counts) - 1)
+            pct = count / n * 100
+            cat_connector = '\u2514\u2500 ' if is_last_cat else '\u251c\u2500 '
+            lines.append(f'{child_prefix}{cat_connector}{str(cat):<20} {count:>4d}  {pct:>5.1f}%')
+
+    return '\n'.join(lines)
+
+
+def render_cluster_analysis():
+    """Render cluster analysis section (full-width bottom area).
+
+    Shows ARI/NMI and tree breakdown when KMeans labels exist and a
+    metadata column is selected in the Color by dropdown.
+    """
+    df_plot = st.session_state.get("data", None)
+    labels = st.session_state.get("labels", None)
+    kmeans_col = st.session_state.get("kmeans_column", None)
+    color_by = st.session_state.get("color_by_column", None)
+
+    if df_plot is None or labels is None or kmeans_col is None:
+        return
+    if kmeans_col not in df_plot.columns:
+        return
+
+    # Only show analysis when comparing KMeans against a different metadata column
+    if not color_by or color_by == "(none)" or color_by == kmeans_col:
+        return
+    if color_by not in df_plot.columns:
+        return
+
+    from sklearn.metrics import adjusted_rand_score, normalized_mutual_info_score
+
+    st.markdown(f"### Cluster Analysis: {kmeans_col} vs {color_by}")
+
+    # Compute ARI/NMI (exclude "N/A" rows from metric computation)
+    kmeans_labels = df_plot[kmeans_col].values
+    metadata_labels = df_plot[color_by].values
+    valid_mask = metadata_labels != "N/A"
+    n_valid = valid_mask.sum()
+    n_excluded = len(metadata_labels) - n_valid
+
+    if n_valid > 0:
+        ari = adjusted_rand_score(metadata_labels[valid_mask], kmeans_labels[valid_mask])
+        nmi = normalized_mutual_info_score(
+            metadata_labels[valid_mask], kmeans_labels[valid_mask], average_method='arithmetic'
+        )
+
+        col1, col2, col3 = st.columns(3)
+        with col1:
+            st.metric("ARI", f"{ari:.3f}",
+                      help="Adjusted Rand Index: 1 = perfect, 0 = random, <0 = worse than random")
+        with col2:
+            st.metric("NMI", f"{nmi:.3f}",
+                      help="Normalized Mutual Information: 1 = perfect, 0 = no correlation")
+        with col3:
+            st.metric("Evaluated", f"{n_valid:,}",
+                      help=f"Rows with non-null '{color_by}'")
+        if n_excluded > 0:
+            st.caption(f"{n_excluded:,} rows with N/A '{color_by}' excluded from evaluation")
+
+        # Tree-style breakdown
+        tree_output = _build_cluster_tree(df_plot, kmeans_col, color_by)
+        st.code(tree_output, language="text")
+    else:
+        st.info(f"No valid '{color_by}' values to compare with KMeans clusters.")

--- a/apps/precalculated/components/sidebar.py
+++ b/apps/precalculated/components/sidebar.py
@@ -15,7 +15,7 @@ import hashlib
 from typing import Dict, Any, Optional, Tuple, List
 
 from shared.services.clustering_service import ClusteringService
-from shared.components.clustering_controls import render_clustering_backend_controls
+from shared.components.clustering_controls import render_projection_controls, render_kmeans_controls
 from shared.utils.backend import check_cuda_available, resolve_backend, is_oom_error
 from shared.utils.logging_config import get_logger
 
@@ -425,6 +425,7 @@ def render_dynamic_filters() -> Dict[str, Any]:
                     st.session_state.embeddings = None
                     st.session_state.data = None
                     st.session_state.labels = None
+                    st.session_state.kmeans_column = None
                     st.session_state.selected_image_idx = None
 
                     st.success(f"Filtered to {len(filtered_df):,} records")
@@ -527,43 +528,60 @@ def extract_embeddings_safe(df: pd.DataFrame) -> np.ndarray:
     return embeddings
 
 
-def render_clustering_section() -> Tuple[bool, int, str, str, str, int, Optional[int]]:
-    """
-    Render the clustering section with VRAM error handling.
-
-    Returns:
-        Tuple of (cluster_button_clicked, n_clusters, reduction_method,
-                  dim_reduction_backend, clustering_backend, n_workers, seed)
-    """
-    with st.expander("🎯 Cluster Embeddings", expanded=False):
+def render_projection_section():
+    """Render the 2D projection section."""
+    with st.expander("Project to 2D", expanded=False):
         filtered_df = st.session_state.get("filtered_df", None)
 
         if filtered_df is None or len(filtered_df) == 0:
-            st.info("Apply filters first to enable clustering.")
-            return False, 5, "TSNE", "auto", "auto", 8, None
+            st.info("Load a parquet file to enable projection.")
+            return
 
-        st.markdown(f"**Ready to cluster:** {len(filtered_df):,} records")
+        st.markdown(f"**Ready to project:** {len(filtered_df):,} records")
 
         # Estimate memory requirements
         emb_dim = len(filtered_df['emb'].iloc[0])
         n_samples = len(filtered_df)
-        est_memory_mb = (n_samples * emb_dim * 4) / (1024 * 1024)  # float32
-
+        est_memory_mb = (n_samples * emb_dim * 4) / (1024 * 1024)
         if est_memory_mb > 1000:
-            st.warning(f"⚠️ Large dataset: ~{est_memory_mb:.0f} MB for embeddings. Consider filtering further if GPU memory is limited.")
+            st.warning(f"Large dataset: ~{est_memory_mb:.0f} MB for embeddings. Consider filtering further if GPU memory is limited.")
+
+        reduction_method = st.selectbox(
+            "Dimensionality Reduction",
+            ["TSNE", "PCA", "UMAP"],
+            help="Method to project high-dimensional embeddings to 2D for visualization."
+        )
+
+        dim_reduction_backend, seed = render_projection_controls()
+
+        if st.button("Project to 2D", type="primary"):
+            _run_projection(filtered_df, reduction_method, dim_reduction_backend, seed)
+
+
+def render_kmeans_section():
+    """Render the optional KMeans clustering section."""
+    with st.expander("KMeans Clustering", expanded=False):
+        df_plot = st.session_state.get("data", None)
+        embeddings = st.session_state.get("embeddings", None)
+
+        if df_plot is None or embeddings is None:
+            st.info("Run projection first to enable KMeans.")
+            return
+
+        filtered_df = st.session_state.get("filtered_df", None)
+        emb_dim = embeddings.shape[1]
+        st.markdown(f"**{len(df_plot):,} points** ({emb_dim}-dim embeddings)")
 
         # Cluster count options
         cluster_method = st.radio(
-            "Cluster count method:",
-            ["Specify number", "Use column values"],
+            "Cluster count:",
+            ["Specify number", "From column"],
             horizontal=True
         )
 
         if cluster_method == "Specify number":
-            n_clusters = st.slider("Number of clusters", 2, min(100, len(filtered_df)//2), 5)
-            cluster_column = None
+            n_clusters = st.slider("Number of clusters", 2, min(100, len(df_plot) // 2), 5)
         else:
-            # Get categorical columns for clustering
             column_info = st.session_state.get("column_info", {})
             categorical_cols = [k for k, v in column_info.items() if v['type'] == 'categorical']
 
@@ -573,168 +591,134 @@ def render_clustering_section() -> Tuple[bool, int, str, str, str, int, Optional
                     categorical_cols,
                     help="Number of clusters = unique values in selected column"
                 )
-                if cluster_column in filtered_df.columns:
+                if filtered_df is not None and cluster_column in filtered_df.columns:
                     n_clusters = filtered_df[cluster_column].nunique()
+                    if n_clusters > 20:
+                        st.warning(
+                            f"**{cluster_column}** has {n_clusters} unique values. "
+                            f"Colors may repeat beyond 20. Consider filtering first."
+                        )
                     st.info(f"Using **{n_clusters}** clusters from {cluster_column}")
                 else:
                     n_clusters = 5
             else:
                 st.warning("No categorical columns available")
                 n_clusters = 5
-                cluster_column = None
 
-        reduction_method = st.selectbox(
-            "Dimensionality Reduction",
-            ["TSNE", "PCA", "UMAP"],
-            help="For 2D visualization only. Clustering uses full embeddings."
-        )
+        clustering_backend, n_workers, seed = render_kmeans_controls()
 
-        # Backend controls
-        dim_reduction_backend, clustering_backend, n_workers, seed = render_clustering_backend_controls()
-
-        cluster_button = st.button("Run Clustering", type="primary")
-
-        if cluster_button:
-            run_clustering_with_error_handling(
-                filtered_df, n_clusters, reduction_method,
-                dim_reduction_backend, clustering_backend, n_workers, seed,
-                cluster_column if cluster_method == "Use column values" else None
-            )
-
-        return cluster_button, n_clusters, reduction_method, dim_reduction_backend, clustering_backend, n_workers, seed
+        if st.button("Run KMeans", type="primary"):
+            _run_kmeans(embeddings, n_clusters, clustering_backend, n_workers, seed)
 
 
-def run_clustering_with_error_handling(
-    filtered_df: pd.DataFrame,
-    n_clusters: int,
-    reduction_method: str,
-    dim_reduction_backend: str,
-    clustering_backend: str,
-    n_workers: int,
-    seed: Optional[int],
-    cluster_column: Optional[str] = None
-):
-    """
-    Run clustering with comprehensive error handling for VRAM and CUDA issues.
-    """
+def _run_projection(filtered_df, reduction_method, dim_reduction_backend, seed):
+    """Run dim reduction and create the 2D scatter plot dataframe."""
     try:
-        # Check CUDA availability
         cuda_available, device_info = check_cuda_available()
+        actual_backend = resolve_backend(dim_reduction_backend, "reduction")
 
-        # Resolve auto backends
-        actual_dim_backend = resolve_backend(dim_reduction_backend, "reduction")
-        actual_cluster_backend = resolve_backend(clustering_backend, "clustering")
-
-        # Log clustering start
         logger.info("=" * 60)
-        logger.info("CLUSTERING START")
-        logger.info("=" * 60)
+        logger.info("PROJECTION START")
         logger.info(f"Device: {device_info} (CUDA: {'Yes' if cuda_available else 'No'})")
-        logger.info(f"Dim Reduction Backend: {actual_dim_backend} (requested: {dim_reduction_backend})")
-        logger.info(f"Clustering Backend: {actual_cluster_backend} (requested: {clustering_backend})")
+        logger.info(f"Backend: {actual_backend} (requested: {dim_reduction_backend})")
 
-        # Extract embeddings
         t_start = time.time()
         with st.spinner("Extracting embeddings..."):
             embeddings = extract_embeddings_safe(filtered_df)
             st.session_state.embeddings = embeddings
-        t_extract = time.time() - t_start
 
         n_samples, emb_dim = embeddings.shape
-        mem_mb = (n_samples * emb_dim * 4) / (1024 * 1024)
+        logger.info(f"Records: {n_samples:,} | Dim: {emb_dim} | Extracted in {time.time() - t_start:.2f}s")
 
-        logger.info(f"Records: {n_samples:,} | Embedding dim: {emb_dim}")
-        logger.info(f"Memory: ~{mem_mb:.1f} MB | Clusters: {n_clusters}")
-        logger.info(f"Embeddings extracted ({t_extract:.2f}s)")
-
-        # Run clustering with automatic GPU fallback
-        t_cluster_start = time.time()
-        with st.spinner(f"Running {reduction_method} + KMeans..."):
-            df_plot, labels = ClusteringService.run_clustering_safe(
-                embeddings,
-                filtered_df['uuid'].tolist(),
-                n_clusters,
-                reduction_method,
-                n_workers,
-                actual_dim_backend,
-                actual_cluster_backend,
-                seed
+        with st.spinner(f"Running {reduction_method}..."):
+            reduced = ClusteringService.run_dim_reduction_safe(
+                embeddings, reduction_method,
+                n_workers=8, dim_reduction_backend=actual_backend, seed=seed
             )
 
-        t_cluster = time.time() - t_cluster_start
         t_total = time.time() - t_start
+        logger.info(f"Projection complete in {t_total:.2f}s")
 
-        # Log clustering completion to console
-        logger.info(f"{reduction_method} + KMeans completed ({t_cluster:.2f}s)")
-        logger.info(f"Total time: {t_total:.2f}s")
+        # Create plot dataframe (no cluster column)
+        df_plot = _create_projection_dataframe(filtered_df.reset_index(drop=True), reduced)
 
-        # Create enhanced plot dataframe
-        df_plot = create_cluster_dataframe(filtered_df.reset_index(drop=True), df_plot[['x', 'y']].values, labels)
+        # Carry over any existing KMeans columns from previous df_plot
+        prev_df = st.session_state.get("data")
+        if prev_df is not None and len(prev_df) == len(df_plot):
+            for col in prev_df.columns:
+                if col.startswith("KMeans (k="):
+                    df_plot[col] = prev_df[col].values
 
-        # Handle column-based cluster names
-        if cluster_column and cluster_column in filtered_df.columns:
-            filtered_reset = filtered_df.reset_index(drop=True)
-            unique_taxa = sorted(filtered_df[cluster_column].dropna().unique())
-            taxon_to_id = {taxon: str(i) for i, taxon in enumerate(unique_taxa)}
-
-            taxonomic_names = []
-            numeric_clusters = []
-
-            for idx in range(len(df_plot)):
-                taxon_value = filtered_reset.iloc[idx][cluster_column]
-                if pd.notna(taxon_value) and taxon_value in taxon_to_id:
-                    taxonomic_names.append(str(taxon_value))
-                    numeric_clusters.append(taxon_to_id[taxon_value])
-                else:
-                    taxonomic_names.append("Unknown")
-                    numeric_clusters.append(str(len(unique_taxa)))
-
-            df_plot['cluster'] = numeric_clusters
-            df_plot['cluster_name'] = taxonomic_names
-            st.session_state.taxonomic_clustering = {'is_taxonomic': True, 'column': cluster_column}
-        else:
-            df_plot['cluster_name'] = df_plot['cluster'].copy()
-            st.session_state.taxonomic_clustering = {'is_taxonomic': False}
-
-        # Store results with data version tracking
-        data_hash = hashlib.md5(f"{len(df_plot)}_{n_clusters}_{reduction_method}".encode()).hexdigest()[:8]
-
+        # Store results
+        data_hash = hashlib.md5(f"{len(df_plot)}_{reduction_method}_{t_total}".encode()).hexdigest()[:8]
         st.session_state.data = df_plot
-        st.session_state.labels = labels
-        st.session_state.data_version = data_hash  # Track data version for selection validation
-        st.session_state.selected_image_idx = None  # User must click to select (not auto-select)
+        st.session_state.data_version = data_hash
+        st.session_state.selected_image_idx = None
         st.session_state.filtered_df_for_clustering = filtered_df.reset_index(drop=True)
 
-        # Final log with success
-        logger.info(f"Clustering complete: {n_clusters} clusters found")
         logger.info("=" * 60)
-
-        st.success(f"Clustering complete! {n_clusters} clusters found.")
+        st.success(f"Projected {n_samples:,} points to 2D using {reduction_method}.")
 
     except (RuntimeError, OSError) as e:
         if is_oom_error(e):
             st.error("**GPU Out of Memory**")
             st.info("Try: Reduce dataset size with more filters, use 'sklearn' backend, or use PCA")
-            logger.exception("GPU OOM error during clustering")
+            logger.exception("GPU OOM during projection")
         else:
-            st.error(f"Error during clustering: {e}")
-            logger.exception("Clustering error")
-
+            st.error(f"Error during projection: {e}")
+            logger.exception("Projection error")
     except MemoryError:
         st.error("**System Out of Memory** - Reduce dataset size")
-        logger.exception("System memory exhausted during clustering")
-
+        logger.exception("System memory exhausted during projection")
     except Exception as e:
         st.error(f"Error: {e}")
-        logger.exception("Unexpected clustering error")
+        logger.exception("Unexpected projection error")
 
 
-def create_cluster_dataframe(df: pd.DataFrame, embeddings_2d: np.ndarray, labels: np.ndarray) -> pd.DataFrame:
-    """Create a dataframe for clustering visualization."""
+def _run_kmeans(embeddings, n_clusters, clustering_backend, n_workers, seed):
+    """Run KMeans on already-extracted embeddings and add labels to df_plot."""
+    try:
+        actual_backend = resolve_backend(clustering_backend, "clustering")
+        logger.info(f"KMeans: k={n_clusters}, backend={actual_backend}")
+
+        with st.spinner(f"Running KMeans (k={n_clusters})..."):
+            labels = ClusteringService.run_kmeans_only_safe(
+                embeddings, n_clusters,
+                n_workers=n_workers, clustering_backend=actual_backend, seed=seed
+            )
+
+        # Add KMeans column to existing df_plot (keep previous runs)
+        df_plot = st.session_state.data
+        kmeans_col = f"KMeans (k={n_clusters})"
+
+        df_plot[kmeans_col] = labels.astype(str)
+        st.session_state.data = df_plot
+        st.session_state.labels = labels
+        st.session_state.kmeans_column = kmeans_col
+
+        logger.info(f"KMeans complete: {len(np.unique(labels))} clusters")
+        st.success(f"KMeans complete! {len(np.unique(labels))} clusters assigned.")
+
+    except (RuntimeError, OSError) as e:
+        if is_oom_error(e):
+            st.error("**GPU Out of Memory**")
+            logger.exception("GPU OOM during KMeans")
+        else:
+            st.error(f"Error during KMeans: {e}")
+            logger.exception("KMeans error")
+    except MemoryError:
+        st.error("**System Out of Memory** - Reduce dataset size")
+        logger.exception("System memory exhausted during KMeans")
+    except Exception as e:
+        st.error(f"Error: {e}")
+        logger.exception("Unexpected KMeans error")
+
+
+def _create_projection_dataframe(df: pd.DataFrame, embeddings_2d: np.ndarray) -> pd.DataFrame:
+    """Create a dataframe for 2D projection visualization (no cluster column)."""
     df_plot = pd.DataFrame({
         "x": embeddings_2d[:, 0],
         "y": embeddings_2d[:, 1],
-        "cluster": labels.astype(str),
         "uuid": df['uuid'].values,
         "idx": range(len(df))
     })

--- a/apps/precalculated/components/sidebar.py
+++ b/apps/precalculated/components/sidebar.py
@@ -542,7 +542,7 @@ def render_projection_section():
         # Estimate memory requirements
         emb_dim = len(filtered_df['emb'].iloc[0])
         n_samples = len(filtered_df)
-        est_memory_mb = (n_samples * emb_dim * 4) / (1024 * 1024)
+        est_memory_mb = (n_samples * emb_dim * 4) / (1024 * 1024)  # float32
         if est_memory_mb > 1000:
             st.warning(f"Large dataset: ~{est_memory_mb:.0f} MB for embeddings. Consider filtering further if GPU memory is limited.")
 
@@ -652,8 +652,8 @@ def _run_projection(filtered_df, reduction_method, dim_reduction_backend, seed):
         # Store results
         data_hash = hashlib.md5(f"{len(df_plot)}_{reduction_method}_{t_total}".encode()).hexdigest()[:8]
         st.session_state.data = df_plot
-        st.session_state.data_version = data_hash
-        st.session_state.selected_image_idx = None
+        st.session_state.data_version = data_hash  # Track data version for selection validation
+        st.session_state.selected_image_idx = None  # User must click to select (not auto-select)
         st.session_state.filtered_df_for_clustering = filtered_df.reset_index(drop=True)
 
         logger.info("=" * 60)

--- a/shared/components/clustering_controls.py
+++ b/shared/components/clustering_controls.py
@@ -80,6 +80,73 @@ def render_clustering_backend_controls():
     return dim_reduction_backend, clustering_backend, n_workers, seed
 
 
+def render_projection_controls():
+    """
+    Render backend controls for dimensionality reduction only.
+
+    Returns:
+        Tuple of (dim_reduction_backend, seed)
+    """
+    dim_reduction_options = ["auto", "sklearn"]
+    if HAS_CUML_PACKAGE and HAS_CUPY_PACKAGE:
+        dim_reduction_options.append("cuml")
+
+    use_seed = st.checkbox("Use fixed seed", value=False, help="Enable for reproducible results",
+                           key="proj_use_seed")
+    if use_seed:
+        seed = st.number_input("Random seed", min_value=0, max_value=999999, value=614, step=1,
+                               key="proj_seed")
+    else:
+        seed = None
+
+    with st.expander("Backend:", expanded=False):
+        dim_reduction_backend = st.selectbox(
+            "Dim Reduction Backend",
+            options=dim_reduction_options, index=0,
+            help="Backend for PCA/t-SNE/UMAP computation",
+            key="proj_backend"
+        )
+
+    return dim_reduction_backend, seed
+
+
+def render_kmeans_controls():
+    """
+    Render backend controls for KMeans only.
+
+    Returns:
+        Tuple of (clustering_backend, n_workers, seed)
+    """
+    clustering_options = ["auto", "sklearn"]
+    if HAS_FAISS_PACKAGE:
+        clustering_options.append("faiss")
+    if HAS_CUML_PACKAGE and HAS_CUPY_PACKAGE:
+        clustering_options.append("cuml")
+
+    use_seed = st.checkbox("Use fixed seed", value=False, help="Enable for reproducible results",
+                           key="km_use_seed")
+    if use_seed:
+        seed = st.number_input("Random seed", min_value=0, max_value=999999, value=614, step=1,
+                               key="km_seed")
+    else:
+        seed = None
+
+    with st.expander("Backend:", expanded=False):
+        clustering_backend = st.selectbox(
+            "Clustering Backend",
+            options=clustering_options, index=0,
+            help="Backend for K-means computation",
+            key="km_backend"
+        )
+        n_workers = st.number_input(
+            "N workers", min_value=1, max_value=64, value=8, step=1,
+            help="Parallel workers for CPU backends",
+            key="km_workers"
+        )
+
+    return clustering_backend, n_workers, seed
+
+
 def render_basic_clustering_controls():
     """
     Render basic clustering parameter controls.

--- a/shared/components/summary.py
+++ b/shared/components/summary.py
@@ -17,36 +17,50 @@ def render_taxonomic_tree_summary():
     labels = st.session_state.get("labels", None)
     filtered_df = st.session_state.get("filtered_df_for_clustering", None)
 
-    if df_plot is not None and labels is not None and filtered_df is not None:
+    if df_plot is not None and filtered_df is not None:
         st.markdown("### Taxonomic Distribution")
 
+        # Detect available KMeans columns
+        kmeans_cols = sorted(
+            [c for c in df_plot.columns if c.startswith("KMeans (k=")],
+            key=lambda c: int(c.split("=")[1].rstrip(")"))
+        )
+        # Fallback for embed_explore app (has 'cluster' column directly)
+        has_embed_explore_cluster = 'cluster' in df_plot.columns and not kmeans_cols
+
         # Add controls at the top of the taxonomy section
-        col1, col2, col3 = st.columns([2, 1, 1])
+        col1, col2, col3, col4 = st.columns([1.5, 1.5, 1, 1])
 
         with col1:
-            # Get available clusters
-            cluster_options = ["All"]
-            if "cluster" in df_plot.columns:
-                # Check if we have taxonomic clustering with cluster names
-                taxonomic_info = st.session_state.get("taxonomic_clustering", {})
-                is_taxonomic = taxonomic_info.get('is_taxonomic', False)
+            if kmeans_cols:
+                # Precalculated app: let user pick which KMeans run
+                group_by = st.selectbox(
+                    "Group by",
+                    options=["(none)"] + kmeans_cols,
+                    index=0,
+                    key="taxonomy_group_by",
+                    help="Select a KMeans result to filter taxonomy by cluster"
+                )
+                if group_by == "(none)":
+                    group_by = None
+            elif has_embed_explore_cluster:
+                group_by = "cluster"
+            else:
+                group_by = None
 
-                if is_taxonomic and 'cluster_name' in df_plot.columns:
-                    # Use taxonomic names for display
-                    unique_cluster_names = sorted(df_plot["cluster_name"].unique())
-                    cluster_options.extend(unique_cluster_names)
-                else:
-                    # Standard numeric clustering
-                    unique_clusters = sorted(df_plot["cluster"].unique(), key=lambda x: int(x))
-                    cluster_options.extend([f"Cluster {c}" for c in unique_clusters])
-
-            selected_cluster = st.selectbox(
-                "Display taxonomy for:",
-                options=cluster_options,
-                index=0,
-                key="taxonomy_cluster_selector",
-                help="Select a specific cluster to show its taxonomy tree, or 'All' to show the entire dataset"
-            )
+        with col2:
+            if group_by and group_by in df_plot.columns:
+                unique_clusters = sorted(df_plot[group_by].unique(), key=lambda x: int(x))
+                cluster_options = ["All"] + [str(c) for c in unique_clusters]
+                selected_cluster = st.selectbox(
+                    "Cluster",
+                    options=cluster_options,
+                    index=0,
+                    key="taxonomy_cluster_selector",
+                    help="Select a specific cluster or 'All'"
+                )
+            else:
+                selected_cluster = "All"
 
         with col2:
             min_count = st.number_input(
@@ -69,50 +83,27 @@ def render_taxonomic_tree_summary():
                 help="Maximum depth of the taxonomy tree to display"
             )
 
-        # Create a stable cache key based on the data characteristics and filter parameters
-        # Use data length and a sample of UUIDs for a stable data identifier
+        # Create a stable cache key
         data_length = len(filtered_df)
-        # Use a stable string representation instead of hash for consistency
         sample_uuids = filtered_df['uuid'].iloc[:min(10, len(filtered_df))].tolist()
         data_id = f"{data_length}_{len(sample_uuids)}_{sample_uuids[0] if sample_uuids else 'empty'}"
-        cache_key = f"taxonomy_{data_id}_{selected_cluster}_{min_count}_{tree_depth}"
+        cache_key = f"taxonomy_{data_id}_{group_by}_{selected_cluster}_{min_count}_{tree_depth}"
 
-        # Check if we have cached results and they're still valid
-        # Also ensure critical session state data hasn't changed unexpectedly
         current_cache_key = st.session_state.get("taxonomy_cache_key")
         cache_exists = cache_key in st.session_state
 
         if (not cache_exists or current_cache_key != cache_key):
 
-            # Data or parameters changed, regenerate taxonomy tree
             with st.spinner("Building taxonomy tree..."):
-                # Filter data based on selected cluster
-                if selected_cluster != "All":
-                    taxonomic_info = st.session_state.get("taxonomic_clustering", {})
-                    is_taxonomic = taxonomic_info.get('is_taxonomic', False)
-
-                    if is_taxonomic and 'cluster_name' in df_plot.columns:
-                        # For taxonomic clustering, filter by cluster_name
-                        cluster_mask = df_plot['cluster_name'] == selected_cluster
-                        cluster_uuids = df_plot[cluster_mask]['uuid'].tolist()
-                        tree_df = filtered_df[filtered_df['uuid'].isin(cluster_uuids)]
-                        display_title = f"Taxonomic Tree for {selected_cluster}"
-                    elif selected_cluster.startswith("Cluster "):
-                        # For numeric clustering, extract cluster ID
-                        cluster_id = selected_cluster.replace("Cluster ", "")
-                        cluster_mask = df_plot['cluster'] == cluster_id
-                        cluster_uuids = df_plot[cluster_mask]['uuid'].tolist()
-                        tree_df = filtered_df[filtered_df['uuid'].isin(cluster_uuids)]
-                        display_title = f"Taxonomic Tree for {selected_cluster}"
-                    else:
-                        # Fallback: treat as direct cluster name
-                        cluster_mask = df_plot['cluster_name'] == selected_cluster if 'cluster_name' in df_plot.columns else df_plot['cluster'] == selected_cluster
-                        cluster_uuids = df_plot[cluster_mask]['uuid'].tolist()
-                        tree_df = filtered_df[filtered_df['uuid'].isin(cluster_uuids)]
-                        display_title = f"Taxonomic Tree for {selected_cluster}"
+                # Filter data based on group_by + selected_cluster
+                if group_by and selected_cluster != "All" and group_by in df_plot.columns:
+                    cluster_mask = df_plot[group_by] == selected_cluster
+                    cluster_uuids = df_plot[cluster_mask]['uuid'].tolist()
+                    tree_df = filtered_df[filtered_df['uuid'].isin(cluster_uuids)]
+                    display_title = f"Taxonomic Tree for {group_by} = {selected_cluster}"
                 else:
                     tree_df = filtered_df
-                    display_title = "Taxonomic Tree for All Clusters"
+                    display_title = "Taxonomic Tree for All Data"
 
                 # Build taxonomic tree for the selected data (only when needed)
                 tree = build_taxonomic_tree(tree_df)
@@ -159,40 +150,39 @@ def render_clustering_summary(show_taxonomy=False):
     summary_df = st.session_state.get("clustering_summary", None)
     representatives = st.session_state.get("clustering_representatives", None)
 
-    if df_plot is not None and labels is not None:
-        # Check if this is image data or metadata-only data
+    if df_plot is not None:
         has_images = 'image_path' in df_plot.columns
 
         if has_images:
-            # For image data, show the full clustering summary
-            st.subheader("Clustering Summary")
+            # embed_explore app: show full clustering summary with representative images
+            if labels is not None:
+                st.subheader("Clustering Summary")
 
-            if summary_df is not None and representatives is not None:
-                logger.debug("Displaying cached clustering summary")
-                st.dataframe(summary_df, hide_index=True, width='stretch')
+                if summary_df is not None and representatives is not None:
+                    logger.debug("Displaying cached clustering summary")
+                    st.dataframe(summary_df, hide_index=True, width='stretch')
 
-                st.markdown("#### Representative Images")
-                for row in summary_df.itertuples():
-                    k = row.Cluster
-                    st.markdown(f"**Cluster {k}**")
-                    img_cols = st.columns(3)
-                    for i, img_idx in enumerate(representatives[k]):
-                        img_path = df_plot.iloc[img_idx]["image_path"]
-                        logger.debug(f"Displaying representative image: {img_path}")
-                        img_cols[i].image(
-                            img_path,
-                            width='stretch',
-                            caption=os.path.basename(img_path)
-                        )
-            else:
-                st.info("Clustering summary will be computed when you run clustering.")
+                    st.markdown("#### Representative Images")
+                    for row in summary_df.itertuples():
+                        k = row.Cluster
+                        st.markdown(f"**Cluster {k}**")
+                        img_cols = st.columns(3)
+                        for i, img_idx in enumerate(representatives[k]):
+                            img_path = df_plot.iloc[img_idx]["image_path"]
+                            logger.debug(f"Displaying representative image: {img_path}")
+                            img_cols[i].image(
+                                img_path,
+                                width='stretch',
+                                caption=os.path.basename(img_path)
+                            )
+                else:
+                    st.info("Clustering summary will be computed when you run clustering.")
         else:
-            # For metadata-only data (precalculated embeddings), show taxonomic tree if requested
+            # Precalculated app: show taxonomy tree (works with or without KMeans)
             if show_taxonomy:
                 filtered_df = st.session_state.get("filtered_df_for_clustering", None)
-
                 if filtered_df is not None:
                     render_taxonomic_tree_summary()
 
     else:
-        st.info("Clustering summary will appear here after clustering.")
+        st.info("Summary will appear here after projection.")

--- a/shared/components/summary.py
+++ b/shared/components/summary.py
@@ -83,12 +83,14 @@ def render_taxonomic_tree_summary():
                 help="Maximum depth of the taxonomy tree to display"
             )
 
-        # Create a stable cache key
+        # Create a stable cache key based on the data characteristics and filter parameters
         data_length = len(filtered_df)
+        # Use a stable string representation instead of hash for consistency
         sample_uuids = filtered_df['uuid'].iloc[:min(10, len(filtered_df))].tolist()
         data_id = f"{data_length}_{len(sample_uuids)}_{sample_uuids[0] if sample_uuids else 'empty'}"
         cache_key = f"taxonomy_{data_id}_{group_by}_{selected_cluster}_{min_count}_{tree_depth}"
 
+        # Check if we have cached results and they're still valid
         current_cache_key = st.session_state.get("taxonomy_cache_key")
         cache_exists = cache_key in st.session_state
 

--- a/shared/components/visualization.py
+++ b/shared/components/visualization.py
@@ -16,14 +16,19 @@ def render_scatter_plot():
     The chart is rendered inside a @st.fragment so that zoom/pan interactions
     only rerun the chart itself — the rest of the page (data preview, summary)
     stays untouched.  A full page rerun is triggered explicitly only when the
-    user clicks a *different* point.
+    user clicks a *different* point or changes the "Color by" column.
     """
     df_plot = st.session_state.get("data", None)
 
     if df_plot is not None and len(df_plot) > 1:
         _render_chart_fragment(df_plot)
     else:
-        st.info("Run clustering to see the cluster scatter plot.")
+        # Detect app type for appropriate message
+        is_precalculated = st.session_state.get("page_type") == "precalculated_app"
+        if is_precalculated:
+            st.info("Run projection to see the scatter plot.")
+        else:
+            st.info("Run clustering to see the cluster scatter plot.")
         st.session_state['selected_image_idx'] = None
 
 
@@ -33,7 +38,10 @@ def _render_chart_fragment(df_plot):
     # Track previous density mode to detect changes
     prev_density_mode = st.session_state.get("_prev_density_mode", None)
 
-    # Plot options in columns for compact layout
+    # Detect app type: precalculated has uuid but no image_path
+    is_precalculated = 'uuid' in df_plot.columns and 'image_path' not in df_plot.columns
+
+    # Plot options
     opt_col1, opt_col2 = st.columns([2, 1])
 
     with opt_col1:
@@ -69,69 +77,134 @@ def _render_chart_fragment(df_plot):
         else:
             heatmap_bins = 40  # Default, not used
 
+    # Determine color column
+    if is_precalculated:
+        # Build list of colorable columns
+        skip_color_cols = {'x', 'y', 'idx', 'uuid', 'emb', 'embedding', 'embeddings', 'vector',
+                           'identifier', 'image_url', 'url', 'img_url', 'image'}
+        colorable_cols = [c for c in df_plot.columns
+                          if c not in skip_color_cols and df_plot[c].nunique() <= 100]
+
+        # Sort KMeans columns to front (all runs, sorted by k)
+        kmeans_cols = sorted(
+            [c for c in colorable_cols if c.startswith("KMeans (k=")],
+            key=lambda c: int(c.split("=")[1].rstrip(")"))
+        )
+        other_cols = [c for c in colorable_cols if not c.startswith("KMeans (k=")]
+        colorable_cols = kmeans_cols + other_cols
+
+        # Build unique count lookup for display
+        col_nunique = {c: df_plot[c].nunique() for c in colorable_cols}
+
+        if colorable_cols:
+            color_col = st.selectbox(
+                "Color by",
+                options=["(none)"] + colorable_cols,
+                index=0,
+                key="color_by_column",
+                format_func=lambda c: c if c == "(none)" else f"{c} ({col_nunique[c]})",
+                help="Select a column to color the points by"
+            )
+            if color_col == "(none)":
+                color_col = None
+        else:
+            color_col = None
+
+        # Warning for high cardinality
+        if color_col and df_plot[color_col].nunique() > 20:
+            st.warning(f"'{color_col}' has {df_plot[color_col].nunique()} unique values. Colors may repeat.")
+
+        # Trigger full page rerun when color changes (so bottom section updates).
+        # Use a sentinel to distinguish "never set" from "set to None".
+        _sentinel = object()
+        prev_color = st.session_state.get("_prev_color_by", _sentinel)
+        if color_col != prev_color:
+            st.session_state["_prev_color_by"] = color_col
+            if prev_color is not _sentinel:
+                st.rerun(scope="app")
+    else:
+        # embed_explore app: always color by cluster
+        color_col = 'cluster' if 'cluster' in df_plot.columns else None
+
     point_selector = alt.selection_point(fields=["idx"], name="point_selection")
 
-    # Determine tooltip fields based on available columns
+    # Build tooltip fields
     tooltip_fields = []
-
-    # Use cluster_name for display if available (taxonomic clustering), otherwise use cluster
-    if 'cluster_name' in df_plot.columns:
-        tooltip_fields.append('cluster_name:N')
-        cluster_legend_title = "Cluster"
-    else:
-        tooltip_fields.append('cluster:N')
-        cluster_legend_title = "Cluster"
-
-    # Add other metadata columns dynamically
-    # Skip technical, ID, and image-URL columns (details available in Data Preview panel)
-    skip_cols = {'x', 'y', 'cluster', 'cluster_name', 'idx',
-                 'emb', 'embedding', 'embeddings', 'vector',
+    skip_cols = {'x', 'y', 'idx', 'emb', 'embedding', 'embeddings', 'vector',
                  'uuid', 'identifier', 'image_url', 'url', 'img_url', 'image'}
+
+    # For embed_explore, include cluster/cluster_name in tooltip
+    if not is_precalculated:
+        if 'cluster_name' in df_plot.columns:
+            tooltip_fields.append('cluster_name:N')
+        elif 'cluster' in df_plot.columns:
+            tooltip_fields.append('cluster:N')
+        skip_cols.update({'cluster', 'cluster_name'})
+
+    # Add the color column first if set (and not already in tooltip)
+    if color_col and color_col not in skip_cols:
+        tooltip_fields.append(f'{color_col}:N')
+        skip_cols.add(color_col)
+
+    # Add remaining metadata columns
     metadata_cols = [c for c in df_plot.columns if c not in skip_cols][:15]
     tooltip_fields.extend(metadata_cols)
 
-    # Determine title based on data type
-    if 'uuid' in df_plot.columns:
-        title = "Embedding Clusters (click a point to view details)"
+    # Title
+    if is_precalculated:
+        title = "Embedding Space (click a point to view details)"
     else:
         title = "Image Clusters (click a point to preview image)"
 
     # Set opacity based on density mode
     if density_mode == "Opacity":
-        point_opacity = 0.15  # Low opacity so overlaps show density
+        point_opacity = 0.15
     elif density_mode == "Heatmap":
-        point_opacity = 0.5  # Medium opacity when heatmap is behind
+        point_opacity = 0.5
     else:
-        point_opacity = 0.7  # Normal opacity
+        point_opacity = 0.7
 
-    # Sort legend labels: numeric sort for cluster IDs, alphabetical for strings
-    unique_vals = df_plot['cluster'].unique()
-    try:
-        sorted_vals = sorted(unique_vals, key=int)
-    except (ValueError, TypeError):
-        sorted_vals = sorted(unique_vals, key=str)
+    # Build chart
+    if color_col:
+        # Sort legend: numeric for KMeans labels, alphabetical for strings
+        unique_vals = df_plot[color_col].unique()
+        try:
+            sorted_vals = sorted(unique_vals, key=int)
+        except (ValueError, TypeError):
+            sorted_vals = sorted(unique_vals, key=str)
 
-    # Create scatter plot
-    scatter = (
-        alt.Chart(df_plot)
-        .mark_circle(size=60, opacity=point_opacity)
-        .encode(
-            x=alt.X('x:Q', scale=alt.Scale(zero=False)),
-            y=alt.Y('y:Q', scale=alt.Scale(zero=False)),
-            color=alt.Color(
-                'cluster:N',
-                legend=alt.Legend(title=cluster_legend_title),
-                sort=sorted_vals,
-                scale=alt.Scale(scheme='tableau20')
-            ),
-            tooltip=tooltip_fields,
-            fillOpacity=alt.condition(point_selector, alt.value(1), alt.value(0.3))
+        scatter = (
+            alt.Chart(df_plot)
+            .mark_circle(size=60, opacity=point_opacity)
+            .encode(
+                x=alt.X('x:Q', scale=alt.Scale(zero=False)),
+                y=alt.Y('y:Q', scale=alt.Scale(zero=False)),
+                color=alt.Color(
+                    f'{color_col}:N',
+                    legend=alt.Legend(title=color_col),
+                    sort=sorted_vals,
+                    scale=alt.Scale(scheme='tableau20')
+                ),
+                tooltip=tooltip_fields,
+                fillOpacity=alt.condition(point_selector, alt.value(1), alt.value(0.3))
+            )
+            .add_params(point_selector)
         )
-        .add_params(point_selector)
-    )
+    else:
+        # No color column: all points same color
+        scatter = (
+            alt.Chart(df_plot)
+            .mark_circle(size=60, opacity=point_opacity)
+            .encode(
+                x=alt.X('x:Q', scale=alt.Scale(zero=False)),
+                y=alt.Y('y:Q', scale=alt.Scale(zero=False)),
+                tooltip=tooltip_fields,
+                fillOpacity=alt.condition(point_selector, alt.value(1), alt.value(0.3))
+            )
+            .add_params(point_selector)
+        )
 
     if density_mode == "Heatmap":
-        # Create 2D density heatmap layer with configurable bins
         density = (
             alt.Chart(df_plot)
             .mark_rect(opacity=0.4)
@@ -145,7 +218,6 @@ def _render_chart_fragment(df_plot):
                 )
             )
         )
-        # Layer density behind scatter
         chart = alt.layer(density, scatter)
     else:
         chart = scatter
@@ -162,23 +234,22 @@ def _render_chart_fragment(df_plot):
             height=700,
             title=title + title_suffix
         )
-        .interactive()  # Enable zoom/pan
+        .interactive()
     )
 
-    # Log chart render only at DEBUG to avoid noise from zoom/pan reruns
     logger.debug(f"[Visualization] Rendering chart: {len(df_plot)} points, density={density_mode}, "
-                 f"bins={heatmap_bins if density_mode == 'Heatmap' else 'N/A'}")
+                 f"color={color_col or 'none'}")
 
-    # Streamlit doesn't support selections on layered charts, so only enable
-    # selection when not using heatmap mode
+    # Include data_version in key so zoom/pan resets when projection changes
+    data_version = st.session_state.get("data_version", "")
+    chart_key = f"alt_chart_{data_version}"
+
     if density_mode == "Heatmap":
-        st.altair_chart(chart, key="alt_chart", width="stretch")
+        st.altair_chart(chart, key=chart_key, width="stretch")
         st.caption("Note: Point selection is disabled when heatmap is shown.")
     else:
-        event = st.altair_chart(chart, key="alt_chart", on_select="rerun", width="stretch")
+        event = st.altair_chart(chart, key=chart_key, on_select="rerun", width="stretch")
 
-        # Handle point selection — only trigger full page rerun when
-        # the selected point actually changes (zoom/pan stay fragment-local)
         if (
             event
             and "selection" in event
@@ -188,9 +259,10 @@ def _render_chart_fragment(df_plot):
             new_idx = int(event["selection"]["point_selection"][0]["idx"])
             prev_idx = st.session_state.get("selected_image_idx")
             if prev_idx != new_idx:
-                cluster = df_plot.iloc[new_idx]['cluster'] if 'cluster' in df_plot.columns else '?'
-                logger.info(f"[Visualization] Point selected: idx={new_idx}, cluster={cluster}")
+                label = ''
+                if color_col and color_col in df_plot.columns:
+                    label = f", {color_col}={df_plot.iloc[new_idx][color_col]}"
+                logger.info(f"[Visualization] Point selected: idx={new_idx}{label}")
                 st.session_state["selected_image_idx"] = new_idx
                 st.session_state["selection_data_version"] = st.session_state.get("data_version", None)
-                # Trigger full page rerun so the preview panel updates
                 st.rerun(scope="app")

--- a/shared/services/clustering_service.py
+++ b/shared/services/clustering_service.py
@@ -92,6 +92,94 @@ class ClusteringService:
         return df_plot, labels
 
     @staticmethod
+    def run_dim_reduction(
+        embeddings: np.ndarray,
+        reduction_method: str,
+        n_workers: int = 1,
+        dim_reduction_backend: str = "auto",
+        seed: Optional[int] = None
+    ) -> np.ndarray:
+        """Run only dimensionality reduction, returning 2D coordinates."""
+        n_samples, n_features = embeddings.shape
+        logger.info(f"Dim reduction: samples={n_samples}, features={n_features}, "
+                    f"method={reduction_method}, backend={dim_reduction_backend}, seed={seed}")
+
+        t_start = time.time()
+        reduced = reduce_dim(
+            embeddings, reduction_method,
+            seed=seed, n_workers=n_workers, backend=dim_reduction_backend
+        )
+        logger.info(f"Dim reduction complete: {reduced.shape} in {time.time() - t_start:.2f}s")
+        return reduced
+
+    @staticmethod
+    def run_dim_reduction_safe(
+        embeddings: np.ndarray,
+        reduction_method: str,
+        n_workers: int = 1,
+        dim_reduction_backend: str = "auto",
+        seed: Optional[int] = None
+    ) -> np.ndarray:
+        """Dim reduction with automatic GPU-to-CPU fallback."""
+        try:
+            return ClusteringService.run_dim_reduction(
+                embeddings, reduction_method, n_workers, dim_reduction_backend, seed
+            )
+        except (RuntimeError, OSError) as e:
+            if is_oom_error(e):
+                raise
+            if is_cuda_arch_error(e) or is_gpu_error(e):
+                logger.warning(f"GPU error ({e}), falling back to sklearn")
+                return ClusteringService.run_dim_reduction(
+                    embeddings, reduction_method, n_workers, "sklearn", seed
+                )
+            raise
+
+    @staticmethod
+    def run_kmeans_only(
+        embeddings: np.ndarray,
+        n_clusters: int,
+        n_workers: int = 1,
+        clustering_backend: str = "auto",
+        seed: Optional[int] = None
+    ) -> np.ndarray:
+        """Run only KMeans, returning labels array."""
+        n_samples, n_features = embeddings.shape
+        logger.info(f"KMeans: samples={n_samples}, features={n_features}, "
+                    f"k={n_clusters}, backend={clustering_backend}, seed={seed}")
+
+        t_start = time.time()
+        _, labels = run_kmeans(
+            embeddings, int(n_clusters),
+            seed=seed, n_workers=n_workers, backend=clustering_backend
+        )
+        logger.info(f"KMeans complete: {len(np.unique(labels))} clusters in {time.time() - t_start:.2f}s")
+        return labels
+
+    @staticmethod
+    def run_kmeans_only_safe(
+        embeddings: np.ndarray,
+        n_clusters: int,
+        n_workers: int = 1,
+        clustering_backend: str = "auto",
+        seed: Optional[int] = None
+    ) -> np.ndarray:
+        """KMeans with automatic GPU-to-CPU fallback."""
+        try:
+            return ClusteringService.run_kmeans_only(
+                embeddings, n_clusters, n_workers, clustering_backend, seed
+            )
+        except (RuntimeError, OSError) as e:
+            if is_oom_error(e):
+                raise
+            if is_cuda_arch_error(e) or is_gpu_error(e):
+                logger.warning(f"GPU error ({e}), falling back to sklearn")
+                return ClusteringService.run_kmeans_only(
+                    embeddings, n_clusters, n_workers, "sklearn", seed
+                )
+            raise
+
+    @staticmethod
     def generate_clustering_summary(
         embeddings: np.ndarray,
         labels: np.ndarray,

--- a/shared/utils/logging_config.py
+++ b/shared/utils/logging_config.py
@@ -62,6 +62,7 @@ def configure_logging(
     root_logger.addHandler(console_handler)
 
     # File handler (append mode, rotates implicitly by date via log dir)
+    file_handler = None
     if log_to_file:
         try:
             os.makedirs(_LOG_DIR, exist_ok=True)
@@ -74,6 +75,17 @@ def configure_logging(
         except OSError:
             # Non-fatal: skip file logging if directory can't be created
             pass
+
+    # Prevent duplicate messages from Streamlit's root logger handler.
+    # Our app loggers (shared.*, apps.*) get their own handlers and don't
+    # propagate to root, avoiding double output from Streamlit's handler.
+    for prefix in ("shared", "apps"):
+        pkg_logger = logging.getLogger(prefix)
+        pkg_logger.propagate = False
+        if not pkg_logger.handlers:
+            pkg_logger.addHandler(console_handler)
+            if file_handler:
+                pkg_logger.addHandler(file_handler)
 
     _logging_configured = True
 


### PR DESCRIPTION
## Summary

Redesign of the precalculated embeddings app that separates two core operation into independent steps:
- dim reduction
- KMeans clustering

Previously these were bundled behind a single "Run Clustering" button, which made it seem like they were dependent on each other, which is misleading, because they both operate independently on the same full-size embedding vectors from the parquet input. 

The new workflow:
1. Project to 2D: reduces embeddings to 2D using TSNE/PCA/UMAP and renders the scatter plot.
2. Color by: a dropdown above the plot lets you color points by any metadata column (kingdom, species, img_type, etc.).
3. Run KMeans (optional): runs KMeans on the full-size embeddings and adds the result as another option in the Color by dropdown. You can run multiple KMeans with different k values, all are kept and available for comparison.

This makes it clear that KMeans is just another label (like kingdom or phylum......), not something that affects the 2D layout. You can visually compare KMeans cluster assignments against any metadata attribute just by switching the Color by dropdown.
