### PR TITLE
Fix categorical column fillna crash in precalculated sidebar

### DIFF
--- a/apps/precalculated/components/sidebar.py
+++ b/apps/precalculated/components/sidebar.py
@@ -726,6 +726,9 @@ def _create_projection_dataframe(df: pd.DataFrame, embeddings_2d: np.ndarray) ->
     # Add available metadata columns for tooltips (fill NaN for clean Altair display)
     for col in df.columns:
         if col not in ['uuid', 'emb', 'embedding', 'embeddings'] and col not in df_plot.columns:
-            df_plot[col] = df[col].fillna("N/A").values
+            series = df[col]
+            if hasattr(series, 'cat'):
+                series = series.astype(str)
+            df_plot[col] = series.fillna("N/A").values
 
     return df_plot


### PR DESCRIPTION
**ERROR**
Loading a parquet with a `dictionary<>` typed column (e.g. a pyarrow categorical) crashes with:
```py
TypeError: Cannot setitem on a Categorical with a new category (N/A), set the categories first
```
This happens in `_create_projection_dataframe()` because `pandas.Categorical.fillna("N/A")` rejects values outside the existing category set. 

**FIX**
Categorical columns in the input `DataFrame` are now converted to strings before filling `NaN` values with `"N/A"` when adding metadata columns to the projection `DataFrame`, ensuring cleaner and more robust Altair displays.

Now after loading a parquet with a dictionary-typed column: previously crashed, now displays "N/A" for nulls.