### PR TITLE
Skip `cuML` probe on CPU-only hosts in `resolve_backend`

### DIFF
--- a/shared/utils/backend.py
+++ b/shared/utils/backend.py
@@ -99,9 +99,8 @@ def resolve_backend(backend: str, operation: str = "general") -> str:
         return backend
 
     cuda_available, device_info = check_cuda_available()
-    has_cuml = check_cuml_available()
-
-    if cuda_available and has_cuml:
+    # Only probe for cuML when CUDA is actually available.
+    if cuda_available and check_cuml_available():
         resolved = "cuml"
         logger.info(f"Auto-resolved {operation} backend to cuML (GPU: {device_info})")
     else:


### PR DESCRIPTION
`check_cuml_available()` does a full `import cuml` which is very slow and pointless when no GPU is present.

`resolve_backend()` now short-circuites: `check_cuml_available()` now only runs when `cuda_available` is True.

I encountered this when using a uv venv that installed `cuml` but the app was running on a login node with no GPU attached. The code was importing `cuml` which slowed down the kick-start time drastically. Fixed it by using a short-circuit optimization, programming 101. 