### PR TITLE
Fix #36 cosmetic `MemoryCache` warning at CLI startup

### DIFF
--- a/apps/embed_explore/app.py
+++ b/apps/embed_explore/app.py
@@ -7,11 +7,6 @@ cluster them, and explore the results visually.
 
 import streamlit as st
 
-from apps.embed_explore.components.sidebar import render_clustering_sidebar
-from apps.embed_explore.components.image_preview import render_image_preview
-from shared.components.summary import render_clustering_summary
-from shared.components.visualization import render_scatter_plot
-
 
 def main():
     """CLI entry point — launches the Streamlit server."""
@@ -25,6 +20,11 @@ def main():
 
 def app():
     """Streamlit application layout."""
+    from apps.embed_explore.components.sidebar import render_clustering_sidebar
+    from apps.embed_explore.components.image_preview import render_image_preview
+    from shared.components.summary import render_clustering_summary
+    from shared.components.visualization import render_scatter_plot
+
     st.set_page_config(
         layout="wide",
         page_title="Embed & Explore",

--- a/apps/precalculated/app.py
+++ b/apps/precalculated/app.py
@@ -7,16 +7,6 @@ Features dynamic filter generation based on available columns.
 
 import streamlit as st
 
-from apps.precalculated.components.sidebar import (
-    render_file_section,
-    render_dynamic_filters,
-    render_projection_section,
-    render_kmeans_section,
-)
-from apps.precalculated.components.data_preview import render_data_preview
-from shared.components.visualization import render_scatter_plot
-from shared.components.summary import render_clustering_summary
-
 
 def main():
     """CLI entry point — launches the Streamlit server."""
@@ -30,6 +20,16 @@ def main():
 
 def app():
     """Streamlit application layout."""
+    from apps.precalculated.components.sidebar import (
+        render_file_section,
+        render_dynamic_filters,
+        render_projection_section,
+        render_kmeans_section,
+    )
+    from apps.precalculated.components.data_preview import render_data_preview
+    from shared.components.visualization import render_scatter_plot
+    from shared.components.summary import render_clustering_summary
+
     st.set_page_config(
         layout="wide",
         page_title="Precalculated Embeddings Explorer",


### PR DESCRIPTION
Streamlit 1.58 emits "No runtime found, using MemoryCacheStorageManager" when `@st.cache_data` is decorated (at import) without a runtime. The CLI lancher imports the app module to reach `main()` before the server runtime exists, so importing any cache-decorated component warns.

The @st.cache_data is a Streamlit decorator, it eagerly initializes a cache-storage manager, which is looking for a runtime.

Breakdown sequence:
```
entry point reach main ->
importing the app modules ->
top-level imports pull in those cache-decorated component modules ->
decoration ran in the bare launcher process (no runtime) ->
warning
```

The fix move component imports into `app()` in both applications so the launcher process never touches `@st.cache_data` decorator. The real server runs `app()` under a live Streamlit runtime.