### PR TITLE
Use exact solver for `cuML` t-SNE to avoid Barnes-Hut collapse

### DIFF
--- a/shared/utils/clustering.py
+++ b/shared/utils/clustering.py
@@ -250,10 +250,13 @@ def _reduce_dim_cuml(embeddings: np.ndarray, method: str, seed: Optional[int], n
             n_samples = embeddings.shape[0]
             perplexity = min(30, max(5, n_samples // 3))
 
+            # Force the exact solver: cuML's default Barnes-Hut collapses to a
+            # ~1D line on near-homogeneous data (#40). exact is O(N^2) but fine
+            # at our interactive scale; a faster Barnes-Hut-with-guard can come later.
             if seed is not None:
-                reducer = cuTSNE(n_components=2, perplexity=perplexity, random_state=seed)
+                reducer = cuTSNE(n_components=2, perplexity=perplexity, method="exact", random_state=seed)
             else:
-                reducer = cuTSNE(n_components=2, perplexity=perplexity)
+                reducer = cuTSNE(n_components=2, perplexity=perplexity, method="exact")
         else:
             raise ValueError("Unsupported method. Choose 'PCA', 'TSNE', or 'UMAP'.")
 


### PR DESCRIPTION
cuML's default Barnes-Hut t-SNE collapses to a ~1D diagonal line on near-homogeneous embeddings, we're able to reproduce this on the Darwin's finches BioCLIP 2 embeddings. **The "exact" solver fix this easily.**

Force method="exact" for the cuML t-SNE path. It's O(N^2) but fine at the interactive scale this app runs; a faster Barnes-Hut-with-degeneracy-guard can be revisited later.

Closes #40 