### PR TITLE
Make PCA projection reproducible given seed

### DIFF
--- a/shared/utils/clustering.py
+++ b/shared/utils/clustering.py
@@ -199,7 +199,9 @@ def _reduce_dim_sklearn(embeddings: np.ndarray, method: str, seed: Optional[int]
     effective_workers = -1 if n_workers > 1 else n_workers
 
     if method.upper() == "PCA":
-        reducer = PCA(n_components=2)
+        # Pass random_state so the randomized SVD solver (auto-selected for
+        # large inputs) is reproducible when a seed is set; None keeps it random.
+        reducer = PCA(n_components=2, random_state=seed)
     elif method.upper() == "TSNE":
         # Adjust perplexity to be valid for the sample size
         n_samples = embeddings.shape[0]
@@ -244,6 +246,8 @@ def _reduce_dim_cuml(embeddings: np.ndarray, method: str, seed: Optional[int], n
 
         if method.upper() == "PCA":
             from cuml.decomposition import PCA as cuPCA
+            # cuML PCA takes no random_state and needs none: its full-SVD solver
+            # is deterministic, so results are already reproducible run-to-run.
             reducer = cuPCA(n_components=2)
         elif method.upper() == "TSNE":
             from cuml.manifold import TSNE as cuTSNE


### PR DESCRIPTION
sklearn auto-selects the randomized SVD solver for large inputs, calling PCA(n_components=2) without `random_state` produced a different projection on every run. Now fixed by passing the seed to the API call.

[cuML ](https://docs.rapids.ai/api/cuml/nightly/api/generated/cuml.decomposition.pca/) PCA is left unchanged: it has no `random_state` parameter (passing one raises TypeError and silently falls back to sklearn), and its full-SVD solver is already deterministic. Verified on a V100: cuML PCA stays on GPU path and is reproducible run-to-run. Changing the solver to "jacobi" **doesn't make sense** for the interactive scale data with 768 dim. 

<img width="906" height="117" alt="{546A243E-7139-4D64-B8BB-C2688E81E020}" src="https://github.com/user-attachments/assets/2467b3e6-9ac2-4ccc-9c4d-0d78b1b74b95" />
